### PR TITLE
Feature/see

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     version: str = "1.0.0"  # Version of the API
     API_V1_STR: str = f"/api/v{version}"  # Path to the base API
     ENVIRONMENT: Literal[
-        "local", "staging", "production"] = "production" if "aimo" in socket.gethostname() else "local"  # Environment of the application
+        "local", "staging", "production"] = "production" if "ai-model-service" in socket.gethostname() else "local"  # Environment of the application
 
     BACKEND_CORS_ORIGINS: List[str] = field(default_factory=lambda: ["*"])  # Allowed origins for CORS
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,3 +1,4 @@
+import socket
 from dataclasses import field
 from typing import Literal, List
 
@@ -14,7 +15,8 @@ Description:
 class Settings(BaseSettings):
     version: str = "1.0.0"  # Version of the API
     API_V1_STR: str = f"/api/v{version}"  # Path to the base API
-    ENVIRONMENT: Literal["local", "staging", "production"] = "local"  # Environment of the application
+    ENVIRONMENT: Literal[
+        "local", "staging", "production"] = "production" if "aimo" in socket.gethostname() else "local"  # Environment of the application
 
     BACKEND_CORS_ORIGINS: List[str] = field(default_factory=lambda: ["*"])  # Allowed origins for CORS
 


### PR DESCRIPTION
This pull request includes a change to the `app/core/config.py` file to dynamically set the environment based on the hostname.

* [`app/core/config.py`](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bR1): Imported the `socket` module to determine the hostname and set the `ENVIRONMENT` variable to "production" if the hostname contains "ai-model-service", otherwise set it to "local". [[1]](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bR1) [[2]](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bL17-R19)