### PR TITLE
Adjust logging level and debug mode in main.py based on environment s…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,7 @@ Description:
 
 # Configure logging settings
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.DEBUG if settings.ENVIRONMENT == 'local' else logging.WARNING,
     format="%(asctime)s - %(levelname)s - %(message)s"
 )
 
@@ -34,7 +34,8 @@ app = FastAPI(
     title=settings.PROJECT_NAME,  # Title on generated documentation
     openapi_url=f"{settings.API_V1_STR}/openapi.json",  # Path to generated OpenAPI documentation
     generate_unique_id_function=custom_generate_unique_id,  # Custom function for generating unique route IDs
-    version=settings.version  # Version of the API
+    version=settings.version,  # Version of the API
+    debug=True if settings.ENVIRONMENT == 'local' else False
 )
 
 # Configure CORS settings


### PR DESCRIPTION
This pull request includes changes to the `app/main.py` file to adjust logging levels and enable debugging based on the environment.

Environment-based configuration changes:

* [`app/main.py`](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL22-R22): Modified the logging level to be `DEBUG` if the environment is local, otherwise set to `WARNING`.
* [`app/main.py`](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL37-R38): Added a condition to enable debugging if the environment is local