### PR TITLE
Fix duplicate "data:" prefix in SSE stream

### DIFF
--- a/app/ai/aimo.py
+++ b/app/ai/aimo.py
@@ -70,7 +70,7 @@ class AIMO:
     def get_constructed_api_messages(self, messages: List[Message]):
         last_message = messages.pop()
         # Check if the last message is from the user
-        if (last_message.role != "user"):
+        if last_message.role != "user":
             raise AIMOException("The last message must be from the user")
         user_input = last_message.content
 

--- a/app/ai/aimo.py
+++ b/app/ai/aimo.py
@@ -138,11 +138,16 @@ class AIMO:
                         continue
                         
                     decoded_line = decode_response(line)
-                    if not decoded_line or decoded_line == "[DONE]":
+                    if not decoded_line:
                         continue
 
-                    # Return upstream SSE formatted data
+                    # Handle normal response chunks
                     yield f"{decoded_line}"
+                        
+                    # Check if this is the final chunk with finish_reason: stop
+                    if (decoded_line.get("choices", [{}])[0].get("finish_reason") == "stop"):
+                        # Add the final [DONE] marker after the last chunk
+                        yield "[DONE]"
 
     # LLM API system prompt
     @property

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -1,9 +1,5 @@
-import json
 import logging
 from typing import Union
-from typing import AsyncGenerator
-from uuid import uuid4
-from time import time
 from fastapi import APIRouter
 from sse_starlette.sse import EventSourceResponse
 
@@ -50,9 +46,8 @@ async def create_chat_completion(request: ChatCompletionRequest) -> Union[ChatCo
         )
 
     return EventSourceResponse(
-        aimo.generate_chat_events(
+        aimo.get_response_stream(
             messages=request.messages,
-            model=request.model,
             temperature=request.temperature,
             max_new_tokens=request.max_tokens
         )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,3 @@
+"""
+Models package containing data models used throughout the application.
+"""

--- a/app/models/openai.py
+++ b/app/models/openai.py
@@ -1,0 +1,42 @@
+from typing import List, Optional, Union, Dict
+from pydantic import BaseModel, Field
+from time import time
+from uuid import uuid4
+
+class Message(BaseModel):
+    """Message in a chat conversation"""
+    role: str
+    content: str
+
+class ChatCompletionRequest(BaseModel):
+    """OpenAI Chat Completion Request Format"""
+    model: str = Field(default="aimo-chat")
+    messages: List[Message]
+    temperature: Optional[float] = 1.32
+    top_p: Optional[float] = 0.9
+    n: Optional[int] = 1
+    stream: Optional[bool] = False
+    max_tokens: Optional[int] = 500
+    presence_penalty: Optional[float] = 0.0
+    frequency_penalty: Optional[float] = 0.0
+    user: Optional[str] = None
+
+class ChatChoice(BaseModel):
+    """A choice in a chat completion response"""
+    index: int
+    message: Optional[Message] = None
+    delta: Optional[Dict] = None
+    finish_reason: Optional[str] = None
+
+class ChatCompletionResponse(BaseModel):
+    """OpenAI Chat Completion Response Format"""
+    id: str = Field(default_factory=lambda: f"chatcmpl-{str(uuid4())}")
+    object: str = "chat.completion"
+    created: int = Field(default_factory=lambda: int(time()))
+    model: str
+    choices: List[ChatChoice]
+    usage: Optional[Dict] = Field(default_factory=lambda: {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0
+    })


### PR DESCRIPTION
## Changes
- Simplified the SSE response handling in AIMO class
- Removed unnecessary `generate_chat_events` method
- Stream raw SSE events directly from upstream LLM API
- Fixed issue with duplicate "data:" prefixes in event stream

## Technical Details
- Modified `get_response_stream` to pass through upstream SSE events without re-formatting
- Updated chat router to use simplified stream response
- Removed redundant event wrapping logic
- Maintained OpenAI-compatible response format

## Testing
- Verified SSE events are properly formatted
- Confirmed no duplicate "data:" prefixes
- All existing tests passing

## Impact
- Cleaner event stream output
- Better client compatibility
- Reduced processing overhead

![image](https://github.com/user-attachments/assets/ae9a7ac4-e572-47a5-bb17-faed6659c6ae)